### PR TITLE
Minor Appearance Tweaks to match Blizzard UI

### DIFF
--- a/DruidBar.lua
+++ b/DruidBar.lua
@@ -339,7 +339,7 @@ function DruidBar_TextRenderer()
 			dbarShow(DruidBarTextLeft);
 			dbarShow(DruidBarTextRight);
 			DruidBarTextLeft:SetText(ManaPercentage());
-			DruidBarTextRight:SetText(ManaValues());
+			DruidBarTextRight:SetText(CurrentMana());
 			DruidBarTextLeft:SetTextColor(1,1,1,1);
 			DruidBarTextRight:SetTextColor(1,1,1,1);
 			end
@@ -367,6 +367,10 @@ end
 
 function ManaValues()
 	return floor(DruidBarKey.currentmana).."/"..floor(DruidBarKey.maxmana);
+end
+
+function CurrentMana()
+	return floor(DruidBarKey.currentmana);
 end
 
 function ManaPercentage()

--- a/DruidBar.xml
+++ b/DruidBar.xml
@@ -47,7 +47,7 @@
 					<Anchors>
 						<Anchor point="LEFT" relativeTo="$Parent" relativePoint="LEFT">
 							<Offset>
-								<AbsDimension x="5" y="0"/>
+								<AbsDimension x="7" y="0"/>
 							</Offset>
 						</Anchor>
 					</Anchors>


### PR DESCRIPTION
Changed "Bliz-like" Mana bar to display only current mana.

Changed X Axis offset of Left text to match Blizzard UI.