### PR TITLE
Fix options background and status bar flickering

### DIFF
--- a/DruidBar.lua
+++ b/DruidBar.lua
@@ -2,7 +2,7 @@ local className, inform, lowregentimer, fullmanatimer, lastshift, inCombat,
 			pre_UseAction, shiftload, isMoving, waitonce, firstshift, aquaformid,
 			travelformid, notyet;
 
-local timer = 0;
+DruidBar_ColorStrataTextureDirty = true;
 local lowregentimer = 0;
 local fullmanatimer = 0;
 local DruidBar_Anchored = nil;
@@ -86,14 +86,8 @@ end
 
 function DruidBar_OnUpdate(self, elapsed)
 	if className and className == "DRUID" and DruidBarKey.Enabled then
-		timer = (timer or 0) + elapsed;
 		if not notyet then
 			DruidBar_MaxManaScript();
-			for i = 1, GetNumShapeshiftForms() do
-				local icon = GetShapeshiftFormInfo(i);
-				if icon == "Interface\\Icons\\Ability_Druid_AquaticForm" then aquaformid = i; end
-				if icon == "Interface\\Icons\\Ability_Druid_TravelForm" then travelformid = i; end
-			end
 			notyet = true;
 		end
 
@@ -117,7 +111,7 @@ function DruidBar_OnUpdate(self, elapsed)
 			else
 				DruidBarMana:SetMinMaxValues(0, DruidBarKey.maxmana);
 				DruidBarMana:SetValue(DruidBarKey.currentmana);
-				if timer > 2 then DruidBar_ColorAndStrataAndTexture(); timer = 0; end
+				DruidBar_ColorAndStrataAndTexture();
 				DruidBar_MainGraphics();
 			end
 		--Graphics OFF
@@ -659,6 +653,7 @@ function DruidBar_Enable_ChatCommandHandler(text)
 				DruidBarKey.color[3] = tonumber(msg[4]);
 			end
 		end
+		DruidBar_ColorStrataTextureDirty = true;
 	elseif msg[1] == "debug" then
 		DruidBarKey.Debug = DruidBar_Toggle(DruidBarKey.Debug, "Debug options");
 		DRUIDBAR_FrameSet();
@@ -671,6 +666,7 @@ function DruidBar_Enable_ChatCommandHandler(text)
 			DruidBar_Print("Setting mana bar texture to "..DruidBarKey.manatexture);
 		end
 		DRUIDBAR_FrameSet();
+		DruidBar_ColorStrataTextureDirty = true;
 	elseif msg[1] == "bordertex" then
 		if msg[2] == "default" then
 			DruidBarKey.bordertexture = "Interface\\Tooltips\\UI-StatusBar-Border";
@@ -681,6 +677,7 @@ function DruidBar_Enable_ChatCommandHandler(text)
 
 		end
 		DRUIDBAR_FrameSet();
+		DruidBar_ColorStrataTextureDirty = true;
 	else
 		DRUIDBAROptionsFrame_Toggle();
 	end
@@ -741,6 +738,11 @@ function DruidBar_ShouldBeVisible()
 end
 
 function DruidBar_ColorAndStrataAndTexture()
+	if not DruidBar_ColorStrataTextureDirty then
+		return;
+	end
+	DruidBar_ColorStrataTextureDirty = false;
+
 	DruidBarMana:SetStatusBarColor(DruidBarKey.color[1], DruidBarKey.color[2], DruidBarKey.color[3], DruidBarKey.color[4]);
 	DruidBarManaBackground:SetVertexColor(DruidBarKey.bgcolor[1],DruidBarKey.bgcolor[2],DruidBarKey.bgcolor[3],DruidBarKey.bgcolor[4]);
 	DruidBarBorder:SetVertexColor(DruidBarKey.bordercolor[1],DruidBarKey.bordercolor[2],DruidBarKey.bordercolor[3],DruidBarKey.bordercolor[4]);

--- a/DruidBarClassic.toc
+++ b/DruidBarClassic.toc
@@ -1,10 +1,10 @@
-## Interface: 20503
+## Interface: 30403
 ## Title: Druid Bar Classic
 ## Notes: Shows mana in bear/cat form.
 ## Current Author: Tek (port to WoW Classic)
 ## Original Authors: SkaDemon (GUI: DiabloHu)
 ## SavedVariables: DruidBarKey
-## Version: 0.7.12
+## Version: 0.7.13
 ## X-Curse-Project-ID: 334762
 ## X-WoWI-ID: 25036
 

--- a/Options.lua
+++ b/Options.lua
@@ -313,14 +313,21 @@ function DRUIDBAROptions_GetColor(self)
 	info.b = DruidBarKey.color[3];
 	info.notCheckable = 1;
 	info.opacity = 1.0 - DruidBarKey.color[4];
-	info.swatchFunc = function() DruidBarKey.color[1], DruidBarKey.color[2], DruidBarKey.color[3] = ColorPickerFrame:GetColorRGB(); end
+	info.swatchFunc = function()
+		DruidBar_ColorStrataTextureDirty = true;
+		DruidBarKey.color[1], DruidBarKey.color[2], DruidBarKey.color[3] = ColorPickerFrame:GetColorRGB(); 
+	end
 	info.func = UIDropDownMenuButton_OpenColorPicker;
 	info.hasOpacity = 0;
-	info.opacityFunc = function() DruidBarKey.color[4] = 1.0 - OpacitySliderFrame:GetValue(); end;
+	info.opacityFunc = function()
+		DruidBar_ColorStrataTextureDirty = true;
+		DruidBarKey.color[4] = 1.0 - OpacitySliderFrame:GetValue(); 
+	end;
 	info.cancelFunc = function()    DruidBarKey.color[1] = ColorPickerFrame.previousValues.r;
 									DruidBarKey.color[2] = ColorPickerFrame.previousValues.g;
 									DruidBarKey.color[3] = ColorPickerFrame.previousValues.b;
-									DruidBarKey.color[4] = 1.0 - ColorPickerFrame.previousValues.opacity; end;
+		DruidBarKey.color[4] = 1.0 - ColorPickerFrame.previousValues.opacity;
+	end;
 	getglobal(self:GetName().."_SwatchBg"):SetVertexColor(DruidBarKey.color[1], DruidBarKey.color[2], DruidBarKey.color[3]);
 end
 
@@ -334,10 +341,16 @@ function DRUIDBAROptions_GetBGColor(self)
 	info.b = DruidBarKey.bgcolor[3];
 	info.notCheckable = 1;
 	info.opacity = 1.0 - DruidBarKey.bgcolor[4];
-	info.swatchFunc = function() DruidBarKey.bgcolor[1], DruidBarKey.bgcolor[2], DruidBarKey.bgcolor[3] = ColorPickerFrame:GetColorRGB(); end
+	info.swatchFunc = function()
+		DruidBar_ColorStrataTextureDirty = true;
+		DruidBarKey.bgcolor[1], DruidBarKey.bgcolor[2], DruidBarKey.bgcolor[3] = ColorPickerFrame:GetColorRGB(); 
+	end
 	info.func = UIDropDownMenuButton_OpenColorPicker;
 	info.hasOpacity = 0;
-	info.opacityFunc = function() DruidBarKey.bgcolor[4] = 1.0 - OpacitySliderFrame:GetValue(); end;
+	info.opacityFunc = function()
+		DruidBar_ColorStrataTextureDirty = true;
+		DruidBarKey.bgcolor[4] = 1.0 - OpacitySliderFrame:GetValue();
+	end;
 	info.cancelFunc = function()    DruidBarKey.bgcolor[1] = ColorPickerFrame.previousValues.r;
 									DruidBarKey.bgcolor[2] = ColorPickerFrame.previousValues.g;
 									DruidBarKey.bgcolor[3] = ColorPickerFrame.previousValues.b;
@@ -355,10 +368,16 @@ function DRUIDBAROptions_GetBorderColor(self)
 	info.b = DruidBarKey.bordercolor[3];
 	info.notCheckable = 1;
 	info.opacity = 1.0 - DruidBarKey.bordercolor[4];
-	info.swatchFunc = function() DruidBarKey.bordercolor[1], DruidBarKey.bordercolor[2], DruidBarKey.bordercolor[3] = ColorPickerFrame:GetColorRGB(); end
+	info.swatchFunc = function() 
+		DruidBar_ColorStrataTextureDirty = true;
+		DruidBarKey.bordercolor[1], DruidBarKey.bordercolor[2], DruidBarKey.bordercolor[3] = ColorPickerFrame:GetColorRGB(); 
+	end
 	info.func = UIDropDownMenuButton_OpenColorPicker;
 	info.hasOpacity = 0;
-	info.opacityFunc = function() DruidBarKey.bordercolor[4] = 1.0 - OpacitySliderFrame:GetValue(); end;
+	info.opacityFunc = function()
+		DruidBar_ColorStrataTextureDirty = true;
+		DruidBarKey.bordercolor[4] = 1.0 - OpacitySliderFrame:GetValue();
+	end;
 	info.cancelFunc = function()    DruidBarKey.bordercolor[1] = ColorPickerFrame.previousValues.r;
 									DruidBarKey.bordercolor[2] = ColorPickerFrame.previousValues.g;
 									DruidBarKey.bordercolor[3] = ColorPickerFrame.previousValues.b;

--- a/Options.xml
+++ b/Options.xml
@@ -1,5 +1,7 @@
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
-..\FrameXML\UI.xsd">
+<Ui xmlns="http://www.blizzard.com/wow/ui/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+	                    https://raw.githubusercontent.com/Gethe/wow-ui-source/classic_era/Interface/FrameXML/UI_shared.xsd">
 	<Frame name="DRUIDBAROptionsFrame" parent="UIParent" inherits="BackdropTemplate" toplevel="true" frameStrata="DIALOG" movable="true" enableMouse="true" hidden="true">
 		<KeyValues>
 			<KeyValue key="backdropInfo" value="BACKDROP_DIALOG_32_32" type="global"/>
@@ -43,7 +45,7 @@
 		<Frames>
 			<!-- BAR OPTIONS SUBFRAME -->
 			<!-- Text Header for 'Bar Options' -->
-			<Frame name="DRUIDBAROptions_Bar">
+			<Frame name="DRUIDBAROptions_Bar" inherits="BackdropTemplate">
 				<Size>
 					<AbsDimension x="420" y="200"/>
 				</Size>
@@ -55,20 +57,6 @@
 						</Offset>
 					</Anchor>
 				</Anchors>
-
-				<Backdrop bgFile="Interface\Tooltips\UI-Tooltip-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="8"/>
-					</EdgeSize>
-
-					<TileSize>
-						<AbsValue val="8"/>
-					</TileSize>
-
-					<BackgroundInsets>
-						<AbsInset left="2" right="2" top="2" bottom="2"/>
-					</BackgroundInsets>
-				</Backdrop>
 
 				<Layers>
 					<Layer>
@@ -83,6 +71,19 @@
 						</FontString>
 					</Layer>
 				</Layers>
+
+				<Scripts>
+					<OnLoad>
+						self:SetBackdrop({
+							bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+							edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+							tile = true,
+							edgeSize = 8,
+							tileSize = 8,
+							insets = { left = 2, right = 2, top = 2, bottom = 2 }
+						})
+					</OnLoad>
+				</Scripts>
 			</Frame>
 
 			<!-- IMPORTANT -->
@@ -478,7 +479,7 @@
 
 			<!-- MISC SUBFRAME -->
 			<!-- Text Header for 'Misc' -->
-			<Frame name="DRUIDBAROptions_Misc">
+			<Frame name="DRUIDBAROptions_Misc" inherits="BackdropTemplate">
 				<Size>
 					<AbsDimension x="420" y="60"/>
 				</Size>
@@ -490,20 +491,6 @@
 						</Offset>
 					</Anchor>
 				</Anchors>
-
-				<Backdrop bgFile="Interface\Tooltips\UI-Tooltip-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="8"/>
-					</EdgeSize>
-
-					<TileSize>
-						<AbsValue val="8"/>
-					</TileSize>
-
-					<BackgroundInsets>
-						<AbsInset left="2" right="2" top="2" bottom="2"/>
-					</BackgroundInsets>
-				</Backdrop>
 
 				<Layers>
 					<Layer>
@@ -518,6 +505,19 @@
 						</FontString>
 					</Layer>
 				</Layers>
+
+				<Scripts>
+					<OnLoad>
+						self:SetBackdrop({
+							bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+							edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+							tile = true,
+							edgeSize = 8,
+							tileSize = 8,
+							insets = { left = 2, right = 2, top = 2, bottom = 2 }
+						})
+					</OnLoad>
+				</Scripts>
 			</Frame>
 
 			<Button name="DBColorSwatch" hidden="false" virtual="true">


### PR DESCRIPTION
This pull request does several things:

1. Fixes the options panel backdrop. Previously, all UI elements had a backdrop, but this was changed in Dragonflight. Now, all frames that want a backdrop must inherit from `BackdropTemplate` and set the backdrop either via `KeyValues` (global backdrop) or the `SetBackdrop` function. I opted for the latter approach.
2. Fixes the flickering that occurs when the status bar updates. This was caused by the function `DruidBar_ColorAndStrataAndTexture`. Every time this function was called (every 2 seconds), the bar would briefly refill to full before showing the actual value. As a fix, I decided to only call this function when something changes. Unfortunately, I struggled to find a clean solution for detecting changes, so I added a global variable that gets set every time one of the properties is changed. Although hacky, this seemed to work without issue.
3. Bumps the TOC version and addon version.
